### PR TITLE
Demo Agent Work Contract PR

### DIFF
--- a/.agentdesk/claims/620d256b-fbe8-5e36-a773-85fe6ea936da.json
+++ b/.agentdesk/claims/620d256b-fbe8-5e36-a773-85fe6ea936da.json
@@ -1,0 +1,7 @@
+{
+  "schema_version": "v1alpha1",
+  "mandate_id": "620d256b-fbe8-5e36-a773-85fe6ea936da",
+  "agent": "codex-demo-pr",
+  "claimed_at": "2026-04-24T21:40:33Z",
+  "expires_at": "2026-04-24T23:40:33Z"
+}

--- a/.agentdesk/dogfood/changed-files.json
+++ b/.agentdesk/dogfood/changed-files.json
@@ -1,0 +1,1 @@
+["docs/DEMO_AGENT_WORK_CONTRACT.md"]

--- a/.agentdesk/dogfood/test-report.txt
+++ b/.agentdesk/dogfood/test-report.txt
@@ -1,0 +1,5 @@
+
+> guild@0.1.0 lint:docs /Users/quentinbrosseau/Documents/Codex/2026-04-24-you-re-an-expert-in-ai/guild
+> node scripts/check-doc-links.mjs
+
+ok 38 markdown files

--- a/.agentdesk/handoffs/620d256b-fbe8-5e36-a773-85fe6ea936da/333bce19-4966-4b99-b02f-5ed2b609e3bb.md
+++ b/.agentdesk/handoffs/620d256b-fbe8-5e36-a773-85fe6ea936da/333bce19-4966-4b99-b02f-5ed2b609e3bb.md
@@ -1,0 +1,7 @@
+# Handoff
+
+Mandate: 620d256b-fbe8-5e36-a773-85fe6ea936da
+To: reviewer
+Created: 2026-04-24T21:40:33Z
+
+Demo PR is ready: tiny docs change plus committed AgentDesk proof records for the PR workflow.

--- a/.agentdesk/mandates/620d256b-fbe8-5e36-a773-85fe6ea936da.json
+++ b/.agentdesk/mandates/620d256b-fbe8-5e36-a773-85fe6ea936da.json
@@ -1,0 +1,66 @@
+{
+  "schema_version": "v1alpha1",
+  "taskpack_id": "620d256b-fbe8-5e36-a773-85fe6ea936da",
+  "title": "Dogfood Agent Work Contract PR check",
+  "objective": "Dogfood Agent Work Contract PR check\n\nSource issue:\nUse this issue to verify the GitHub Actions / PR-report copy around agentdesk verify.\\n\\nAcceptance:\\n- README explains agentdesk verify --github-report.\\n- workflow exists under .github/workflows.\\n- report language includes Agent Work Contract: passed, proof, approvals, and replay.",
+  "task_type": "implementation",
+  "priority": "medium",
+  "requested_by": {
+    "actor_id": "54b645e4-a804-5b97-b354-51d07bf81819",
+    "actor_type": "human",
+    "display_name": "daishizenSensei",
+    "orchestrator": "github",
+    "endpoint": "https://github.com/lucid-fdn/guild"
+  },
+  "role_hint": "builder",
+  "references": [
+    "https://github.com/lucid-fdn/guild/issues/3"
+  ],
+  "labels": [
+    "agentdesk",
+    "github",
+    "issue-3",
+    "agent-ready",
+    "priority-p2",
+    "scope-docs"
+  ],
+  "context_budget": {
+    "max_input_tokens": 12000,
+    "max_output_tokens": 1024,
+    "context_strategy": "artifact_refs_first"
+  },
+  "permissions": {
+    "allow_network": false,
+    "allow_shell": true,
+    "allow_external_write": false,
+    "approval_mode": "ask",
+    "scopes": [
+      "src/**",
+      "tests/**",
+      "docs/**"
+    ]
+  },
+  "acceptance_criteria": [
+    {
+      "criterion_id": "criterion_01",
+      "description": "Tests pass or failure is explained.",
+      "required": true
+    },
+    {
+      "criterion_id": "criterion_02",
+      "description": "Every modified file is listed.",
+      "required": true
+    },
+    {
+      "criterion_id": "criterion_03",
+      "description": "A proof artifact is attached.",
+      "required": true
+    },
+    {
+      "criterion_id": "criterion_04",
+      "description": "A reviewer handoff is created.",
+      "required": true
+    }
+  ],
+  "created_at": "2026-04-24T21:21:01Z"
+}

--- a/.agentdesk/proof/620d256b-fbe8-5e36-a773-85fe6ea936da/119770e3-bc90-4d91-8657-fdf559a92c9f.json
+++ b/.agentdesk/proof/620d256b-fbe8-5e36-a773-85fe6ea936da/119770e3-bc90-4d91-8657-fdf559a92c9f.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "v1alpha1",
+  "artifact_id": "119770e3-bc90-4d91-8657-fdf559a92c9f",
+  "taskpack_id": "620d256b-fbe8-5e36-a773-85fe6ea936da",
+  "kind": "test_report",
+  "title": "test-report.txt",
+  "summary": "Markdown docs lint passed for the demo PR.",
+  "producer": {
+    "actor_id": "b44957b7-afdd-4287-8e30-c98e055e2315",
+    "actor_type": "agent",
+    "display_name": "agentdesk-cli",
+    "orchestrator": "agentdesk"
+  },
+  "storage": {
+    "uri": "file:///Users/quentinbrosseau/Documents/Codex/2026-04-24-you-re-an-expert-in-ai/guild/.agentdesk/dogfood/test-report.txt",
+    "mime_type": "text/plain",
+    "sha256": "d659dc8ffc6a3d20f62c2dd08590020adee248b7b6185100a22fcc63c67f0eff",
+    "size_bytes": 161
+  },
+  "labels": [
+    "agentdesk",
+    "proof"
+  ],
+  "version": 1,
+  "created_at": "2026-04-24T21:40:33Z"
+}

--- a/.agentdesk/proof/620d256b-fbe8-5e36-a773-85fe6ea936da/333bce19-4966-4b99-b02f-5ed2b609e3bb.json
+++ b/.agentdesk/proof/620d256b-fbe8-5e36-a773-85fe6ea936da/333bce19-4966-4b99-b02f-5ed2b609e3bb.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "v1alpha1",
+  "artifact_id": "333bce19-4966-4b99-b02f-5ed2b609e3bb",
+  "taskpack_id": "620d256b-fbe8-5e36-a773-85fe6ea936da",
+  "kind": "handoff_summary",
+  "title": "333bce19-4966-4b99-b02f-5ed2b609e3bb.md",
+  "summary": "Handoff to reviewer: Demo PR is ready: tiny docs change plus committed AgentDesk proof records for the PR workflow.",
+  "producer": {
+    "actor_id": "f3fe6220-fea8-4840-9806-9411804bd2a4",
+    "actor_type": "agent",
+    "display_name": "agentdesk-cli",
+    "orchestrator": "agentdesk"
+  },
+  "storage": {
+    "uri": "file:///Users/quentinbrosseau/Documents/Codex/2026-04-24-you-re-an-expert-in-ai/guild/.agentdesk/handoffs/620d256b-fbe8-5e36-a773-85fe6ea936da/333bce19-4966-4b99-b02f-5ed2b609e3bb.md",
+    "mime_type": "text/markdown",
+    "sha256": "e13337812eff9242ecd7ba53f04c7f5a50228b3c58246f174bb8a03372de58d1",
+    "size_bytes": 196
+  },
+  "labels": [
+    "agentdesk",
+    "proof"
+  ],
+  "version": 1,
+  "created_at": "2026-04-24T21:40:33Z"
+}

--- a/.agentdesk/proof/620d256b-fbe8-5e36-a773-85fe6ea936da/8408b9ad-d382-42aa-bd04-56a5d09755ab.json
+++ b/.agentdesk/proof/620d256b-fbe8-5e36-a773-85fe6ea936da/8408b9ad-d382-42aa-bd04-56a5d09755ab.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "v1alpha1",
+  "artifact_id": "8408b9ad-d382-42aa-bd04-56a5d09755ab",
+  "taskpack_id": "620d256b-fbe8-5e36-a773-85fe6ea936da",
+  "kind": "changed_files",
+  "title": "changed-files.json",
+  "summary": "Demo PR changed docs/DEMO_AGENT_WORK_CONTRACT.md.",
+  "producer": {
+    "actor_id": "92a079cc-0ec9-41a2-b686-62f9161a6f87",
+    "actor_type": "agent",
+    "display_name": "agentdesk-cli",
+    "orchestrator": "agentdesk"
+  },
+  "storage": {
+    "uri": "file:///Users/quentinbrosseau/Documents/Codex/2026-04-24-you-re-an-expert-in-ai/guild/.agentdesk/dogfood/changed-files.json",
+    "mime_type": "application/json",
+    "sha256": "bbb6732db55f2ebc78bf1b76d7069aeb23af62168b87c9c3874982a9426008db",
+    "size_bytes": 37
+  },
+  "labels": [
+    "agentdesk",
+    "proof"
+  ],
+  "version": 1,
+  "created_at": "2026-04-24T21:40:33Z"
+}

--- a/.agentdesk/replay/replay.json
+++ b/.agentdesk/replay/replay.json
@@ -1,0 +1,220 @@
+{
+  "schema_version": "v1alpha1",
+  "root_taskpack_id": "620d256b-fbe8-5e36-a773-85fe6ea936da",
+  "taskpack": {
+    "schema_version": "v1alpha1",
+    "taskpack_id": "620d256b-fbe8-5e36-a773-85fe6ea936da",
+    "title": "Dogfood Agent Work Contract PR check",
+    "objective": "Dogfood Agent Work Contract PR check\n\nSource issue:\nUse this issue to verify the GitHub Actions / PR-report copy around agentdesk verify.\\n\\nAcceptance:\\n- README explains agentdesk verify --github-report.\\n- workflow exists under .github/workflows.\\n- report language includes Agent Work Contract: passed, proof, approvals, and replay.",
+    "task_type": "implementation",
+    "priority": "medium",
+    "requested_by": {
+      "actor_id": "54b645e4-a804-5b97-b354-51d07bf81819",
+      "actor_type": "human",
+      "display_name": "daishizenSensei",
+      "orchestrator": "github",
+      "endpoint": "https://github.com/lucid-fdn/guild"
+    },
+    "role_hint": "builder",
+    "references": [
+      "https://github.com/lucid-fdn/guild/issues/3"
+    ],
+    "labels": [
+      "agentdesk",
+      "github",
+      "issue-3",
+      "agent-ready",
+      "priority-p2",
+      "scope-docs"
+    ],
+    "context_budget": {
+      "max_input_tokens": 12000,
+      "max_output_tokens": 1024,
+      "context_strategy": "artifact_refs_first"
+    },
+    "permissions": {
+      "allow_network": false,
+      "allow_shell": true,
+      "allow_external_write": false,
+      "approval_mode": "ask",
+      "scopes": [
+        "src/**",
+        "tests/**",
+        "docs/**"
+      ]
+    },
+    "acceptance_criteria": [
+      {
+        "criterion_id": "criterion_01",
+        "description": "Tests pass or failure is explained.",
+        "required": true
+      },
+      {
+        "criterion_id": "criterion_02",
+        "description": "Every modified file is listed.",
+        "required": true
+      },
+      {
+        "criterion_id": "criterion_03",
+        "description": "A proof artifact is attached.",
+        "required": true
+      },
+      {
+        "criterion_id": "criterion_04",
+        "description": "A reviewer handoff is created.",
+        "required": true
+      }
+    ],
+    "created_at": "2026-04-24T21:21:01Z"
+  },
+  "taskpacks": [
+    {
+      "schema_version": "v1alpha1",
+      "taskpack_id": "620d256b-fbe8-5e36-a773-85fe6ea936da",
+      "title": "Dogfood Agent Work Contract PR check",
+      "objective": "Dogfood Agent Work Contract PR check\n\nSource issue:\nUse this issue to verify the GitHub Actions / PR-report copy around agentdesk verify.\\n\\nAcceptance:\\n- README explains agentdesk verify --github-report.\\n- workflow exists under .github/workflows.\\n- report language includes Agent Work Contract: passed, proof, approvals, and replay.",
+      "task_type": "implementation",
+      "priority": "medium",
+      "requested_by": {
+        "actor_id": "54b645e4-a804-5b97-b354-51d07bf81819",
+        "actor_type": "human",
+        "display_name": "daishizenSensei",
+        "orchestrator": "github",
+        "endpoint": "https://github.com/lucid-fdn/guild"
+      },
+      "role_hint": "builder",
+      "references": [
+        "https://github.com/lucid-fdn/guild/issues/3"
+      ],
+      "labels": [
+        "agentdesk",
+        "github",
+        "issue-3",
+        "agent-ready",
+        "priority-p2",
+        "scope-docs"
+      ],
+      "context_budget": {
+        "max_input_tokens": 12000,
+        "max_output_tokens": 1024,
+        "context_strategy": "artifact_refs_first"
+      },
+      "permissions": {
+        "allow_network": false,
+        "allow_shell": true,
+        "allow_external_write": false,
+        "approval_mode": "ask",
+        "scopes": [
+          "src/**",
+          "tests/**",
+          "docs/**"
+        ]
+      },
+      "acceptance_criteria": [
+        {
+          "criterion_id": "criterion_01",
+          "description": "Tests pass or failure is explained.",
+          "required": true
+        },
+        {
+          "criterion_id": "criterion_02",
+          "description": "Every modified file is listed.",
+          "required": true
+        },
+        {
+          "criterion_id": "criterion_03",
+          "description": "A proof artifact is attached.",
+          "required": true
+        },
+        {
+          "criterion_id": "criterion_04",
+          "description": "A reviewer handoff is created.",
+          "required": true
+        }
+      ],
+      "created_at": "2026-04-24T21:21:01Z"
+    }
+  ],
+  "dri_bindings": [],
+  "artifacts": [
+    {
+      "schema_version": "v1alpha1",
+      "artifact_id": "119770e3-bc90-4d91-8657-fdf559a92c9f",
+      "taskpack_id": "620d256b-fbe8-5e36-a773-85fe6ea936da",
+      "kind": "test_report",
+      "title": "test-report.txt",
+      "summary": "Markdown docs lint passed for the demo PR.",
+      "producer": {
+        "actor_id": "b44957b7-afdd-4287-8e30-c98e055e2315",
+        "actor_type": "agent",
+        "display_name": "agentdesk-cli",
+        "orchestrator": "agentdesk"
+      },
+      "storage": {
+        "uri": "file:///Users/quentinbrosseau/Documents/Codex/2026-04-24-you-re-an-expert-in-ai/guild/.agentdesk/dogfood/test-report.txt",
+        "mime_type": "text/plain",
+        "sha256": "d659dc8ffc6a3d20f62c2dd08590020adee248b7b6185100a22fcc63c67f0eff",
+        "size_bytes": 161
+      },
+      "labels": [
+        "agentdesk",
+        "proof"
+      ],
+      "version": 1,
+      "created_at": "2026-04-24T21:40:33Z"
+    },
+    {
+      "schema_version": "v1alpha1",
+      "artifact_id": "333bce19-4966-4b99-b02f-5ed2b609e3bb",
+      "taskpack_id": "620d256b-fbe8-5e36-a773-85fe6ea936da",
+      "kind": "handoff_summary",
+      "title": "333bce19-4966-4b99-b02f-5ed2b609e3bb.md",
+      "summary": "Handoff to reviewer: Demo PR is ready: tiny docs change plus committed AgentDesk proof records for the PR workflow.",
+      "producer": {
+        "actor_id": "f3fe6220-fea8-4840-9806-9411804bd2a4",
+        "actor_type": "agent",
+        "display_name": "agentdesk-cli",
+        "orchestrator": "agentdesk"
+      },
+      "storage": {
+        "uri": "file:///Users/quentinbrosseau/Documents/Codex/2026-04-24-you-re-an-expert-in-ai/guild/.agentdesk/handoffs/620d256b-fbe8-5e36-a773-85fe6ea936da/333bce19-4966-4b99-b02f-5ed2b609e3bb.md",
+        "mime_type": "text/markdown",
+        "sha256": "e13337812eff9242ecd7ba53f04c7f5a50228b3c58246f174bb8a03372de58d1",
+        "size_bytes": 196
+      },
+      "labels": [
+        "agentdesk",
+        "proof"
+      ],
+      "version": 1,
+      "created_at": "2026-04-24T21:40:33Z"
+    },
+    {
+      "schema_version": "v1alpha1",
+      "artifact_id": "8408b9ad-d382-42aa-bd04-56a5d09755ab",
+      "taskpack_id": "620d256b-fbe8-5e36-a773-85fe6ea936da",
+      "kind": "changed_files",
+      "title": "changed-files.json",
+      "summary": "Demo PR changed docs/DEMO_AGENT_WORK_CONTRACT.md.",
+      "producer": {
+        "actor_id": "92a079cc-0ec9-41a2-b686-62f9161a6f87",
+        "actor_type": "agent",
+        "display_name": "agentdesk-cli",
+        "orchestrator": "agentdesk"
+      },
+      "storage": {
+        "uri": "file:///Users/quentinbrosseau/Documents/Codex/2026-04-24-you-re-an-expert-in-ai/guild/.agentdesk/dogfood/changed-files.json",
+        "mime_type": "application/json",
+        "sha256": "bbb6732db55f2ebc78bf1b76d7069aeb23af62168b87c9c3874982a9426008db",
+        "size_bytes": 37
+      },
+      "labels": [
+        "agentdesk",
+        "proof"
+      ],
+      "version": 1,
+      "created_at": "2026-04-24T21:40:33Z"
+    }
+  ],
+  "promotion_records": []
+}

--- a/docs/DEMO_AGENT_WORK_CONTRACT.md
+++ b/docs/DEMO_AGENT_WORK_CONTRACT.md
@@ -1,0 +1,10 @@
+# Agent Work Contract Demo
+
+This file is intentionally small.
+It exists to dogfood the pull request path where an agent claims a GitHub issue, makes a scoped change, attaches proof, and lets the Agent Work Contract workflow report the result on the PR.
+
+The demo proves the launch loop:
+
+```text
+GitHub issue -> mandate -> claim -> proof -> verify -> replay -> PR report
+```


### PR DESCRIPTION
## Summary

Dogfoods issue #3 by opening a tiny docs-only PR with committed AgentDesk mandate/proof records.

This PR is intentionally small so the Agent Work Contract workflow can be used as launch/demo material.

## Agent Work Contract

- Source issue: closes #3
- Mandate: `620d256b-fbe8-5e36-a773-85fe6ea936da`
- Proof artifacts: `test_report`, `changed_files`, `handoff_summary`
- Local verify: `ready=true`, `proof_count=3`, `pending_approval_count=0`
- Replay: committed under `.agentdesk/replay/replay.json`

## Validation

- `guild agentdesk verify --id 620d256b-fbe8-5e36-a773-85fe6ea936da`
- `guild agentdesk replay export --id 620d256b-fbe8-5e36-a773-85fe6ea936da --file /tmp/guild-demo-pr-replay.json`
- `guild validate --kind replay-bundle --file /tmp/guild-demo-pr-replay.json`
- `corepack pnpm run lint:docs`
